### PR TITLE
Fix: Decrease infinity of the cell cost

### DIFF
--- a/src/game/board/board.gd
+++ b/src/game/board/board.gd
@@ -28,7 +28,7 @@ func load_board_cost() -> void:
 		if parsed_file[atlas_coords] != "inf":
 			continue
 
-		parsed_file[atlas_coords] = 9007199254740991  # 2^53 - 1
+		parsed_file[atlas_coords] = 16777215  # 2^24 - 1
 
 	cost = parsed_file
 
@@ -50,7 +50,7 @@ func init_path_finder() -> void:
 func get_cell_cost(map_index: Vector2i) -> int:
 	var atlas_coords = get_cell_atlas_coords(map_index)
 	var coord_key = "%s,%s" % [atlas_coords.x, atlas_coords.y]
-	return cost.get(coord_key, 9007199254740991)
+	return cost.get(coord_key, 16777215)
 
 
 func get_cell_id(map_index: Vector2i) -> int:
@@ -74,12 +74,12 @@ func get_unit(map_index: Vector2i) -> Unit:
 func add_unit(unit: Unit) -> void:
 	unit.moved.connect(__on_unit_moved)
 	units[unit.player].append(unit)
-	update_cell_cost(unit.map_position, 9007199254740991)
+	update_cell_cost(unit.map_position, 16777215)
 
 
 func __on_unit_moved(unit: Unit, from: Vector2i) -> void:
 	update_cell_cost(from, get_cell_cost(from))
-	update_cell_cost(unit.map_position, 9007199254740991)
+	update_cell_cost(unit.map_position, 16777215)
 
 
 func update_cell_cost(map_index: Vector2i, new_cost: float) -> void:

--- a/src/units/unit.gd
+++ b/src/units/unit.gd
@@ -37,7 +37,7 @@ func get_move_cost(to: Vector2i) -> int:
 	var t := board.get_cell_id(to)
 	var path := board.path_finder.get_point_path(s, t)
 
-	var path_cost := -9007199254740991
+	var path_cost := -16777215
 	for path_cell in path:
 		var u := board.get_cell_id(path_cell)
 		path_cost += board.path_finder.get_point_weight_scale(u) as int
@@ -51,7 +51,7 @@ func get_legal_moves() -> Array[Vector2i]:
 	for cell in board.get_used_cells():
 		var path_cost := get_move_cost(cell)
 
-		if path_cost > 1 and path_cost <= stamina:
+		if path_cost > 0.0 and path_cost <= stamina:
 			legal_moves.append(cell)
 
 	return legal_moves


### PR DESCRIPTION
Reduction of infinity of the cell cost is required for the path cost to be calculated correctly. Godot's implementation of `AStar2D` uses IEEE 754 float for storing cell weights, thus the maximum safe integer is $2^{24} - 1$ ($16,777,215$), not $2^{53} - 1$ ($9,007,199,254,740,991$).

_Resolves [HOW-37]._

[HOW-37]: https://aghcs.atlassian.net/browse/HOW-37?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ